### PR TITLE
fix browser option for dev-env (this actually never worked AFAICS)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,12 @@
 'use strict';
 
-var babelHelpers = {};
-
-babelHelpers.classCallCheck = function (instance, Constructor) {
+var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
     throw new TypeError("Cannot call a class as a function");
   }
 };
 
-babelHelpers.createClass = function () {
+var createClass = function () {
   function defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
       var descriptor = props[i];
@@ -26,8 +24,6 @@ babelHelpers.createClass = function () {
   };
 }();
 
-babelHelpers;
-
 function mergeOptions(options, defaults) {
   for (var key in defaults) {
     if (options.hasOwnProperty(key)) {
@@ -39,7 +35,7 @@ function mergeOptions(options, defaults) {
 
 var WebpackShellPlugin = function () {
   function WebpackShellPlugin(options) {
-    babelHelpers.classCallCheck(this, WebpackShellPlugin);
+    classCallCheck(this, WebpackShellPlugin);
 
     var defaultOptions = {
       port: 8080,
@@ -55,7 +51,7 @@ var WebpackShellPlugin = function () {
     this.outputPath = null;
   }
 
-  babelHelpers.createClass(WebpackShellPlugin, [{
+  createClass(WebpackShellPlugin, [{
     key: 'apply',
     value: function apply(compiler) {
       var _this = this;
@@ -82,7 +78,7 @@ var WebpackShellPlugin = function () {
           if (_this.dev === true) {
             // Running in dev-server @todo check and validate this
             var open = require('open');
-            open('http://127.0.0.1:' + _this.options.port.toString() + '/');
+            open('http://127.0.0.1:' + _this.options.port.toString() + '/', _this.options.browser);
           } else if (_this.dev === false) {
             var browserSync = require('browser-sync');
             browserSync.init({

--- a/src/webpack-browser-plugin.js
+++ b/src/webpack-browser-plugin.js
@@ -47,7 +47,7 @@ export default class WebpackShellPlugin {
         if (this.dev === true) {
           // Running in dev-server @todo check and validate this
           const open = require('open');
-          open(`http://127.0.0.1:${this.options.port.toString()}/`);
+          open(`http://127.0.0.1:${this.options.port.toString()}/`, this.options.browser);
         } else if (this.dev === false) {
           const browserSync = require('browser-sync');
           browserSync.init({


### PR DESCRIPTION
- [x] add browser-param to open()

Reason: the `browser`-param is never actually passed to `open()`: https://github.com/1337programming/webpack-browser-plugin/blob/master/src/webpack-browser-plugin.js#L50
