### PR TITLE
Switched from child_process.spawn to opn to support other platforms

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,12 @@
 'use strict';
 
-var babelHelpers = {};
-
-babelHelpers.classCallCheck = function (instance, Constructor) {
+var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
     throw new TypeError("Cannot call a class as a function");
   }
 };
 
-babelHelpers.createClass = function () {
+var createClass = function () {
   function defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
       var descriptor = props[i];
@@ -26,8 +24,6 @@ babelHelpers.createClass = function () {
   };
 }();
 
-babelHelpers;
-
 function mergeOptions(options, defaults) {
   for (var key in defaults) {
     if (options.hasOwnProperty(key)) {
@@ -39,7 +35,7 @@ function mergeOptions(options, defaults) {
 
 var WebpackBrowserPlugin = function () {
   function WebpackBrowserPlugin(options) {
-    babelHelpers.classCallCheck(this, WebpackBrowserPlugin);
+    classCallCheck(this, WebpackBrowserPlugin);
 
     var defaultOptions = {
       port: 8080,
@@ -57,7 +53,7 @@ var WebpackBrowserPlugin = function () {
     this.outputPath = null;
   }
 
-  babelHelpers.createClass(WebpackBrowserPlugin, [{
+  createClass(WebpackBrowserPlugin, [{
     key: 'apply',
     value: function apply(compiler) {
       var _this = this;
@@ -85,12 +81,10 @@ var WebpackBrowserPlugin = function () {
       compiler.plugin('done', function (compilation) {
         if (_this.firstRun) {
           if (_this.dev === true) {
-            var spawn = require('child_process').spawn;
-            var url = _this.options.url;
-            if (_this.options.port) {
-              url = _this.options.url + ':' + _this.options.port.toString();
-            }
-            spawn('open', [url]);
+            var open = require('opn');
+            var url = _this.options.port ? _this.options.url + ':' + _this.options.port.toString() : _this.options.url;
+            var browser = _this.options.browser;
+            open(url, { app: browser });
           } else if (_this.dev === false) {
             (function () {
               var bs = require('browser-sync').create();

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "browser-sync": "^2.13.0"
+    "browser-sync": "^2.13.0",
+    "opn": "^4.0.2"
   }
 }

--- a/src/webpack-browser-plugin.js
+++ b/src/webpack-browser-plugin.js
@@ -50,12 +50,10 @@ export default class WebpackBrowserPlugin {
     compiler.plugin('done', (compilation) => {
       if (this.firstRun) {
         if (this.dev === true) {
-          var spawn = require('child_process').spawn;
-          var url = this.options.url;
-          if (this.options.port) {
-            url = `${this.options.url}:${this.options.port.toString()}`;
-          }
-          spawn('open', [url]);
+          const open = require('opn');
+          const url = this.options.port ? `${this.options.url}:${this.options.port.toString()}` : this.options.url;
+          const browser = this.options.browser;
+          open(url, { app: browser });
         } else if (this.dev === false) {
           const bs = require('browser-sync').create();
 


### PR DESCRIPTION
Switched from using `child_process#spawn` to open a browser, to `opn` which supports other platforms out-of-the-box.

This should fix this issue: https://github.com/1337programming/webpack-browser-plugin/issues/6#issuecomment-231788867
